### PR TITLE
inquirerのバージョンアップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "dotenv": "^6.2.0",
     "express": "^4.16.4",
-    "inquirer": "^4.0.0",
+    "inquirer": "^6.5.1",
     "lodash": "^4.17.10",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Windows 10、Node v10.16.3環境で[jinzo-ningen](https://github.com/goqoo-on-kintone/jinzo-ningen)のテストが動作しませんでした。
調べてみるとginueのinquirerでpromptを出すとjsonファイルの読み込みが待ちになり続けるようでした。
inquirerを最新にすると動作したのでバージョンアップしてほしいです。