### PR TITLE
クライアント証明書に対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,27 +36,31 @@ Gitライクな一連のコマンドを提供します。
 
 #### コマンドライン引数から指定
 ```
-  -v, --version                 Output version information
-  -h, --help                    Output usage information
-  -d, --domain=<DOMAIN>         kintone domain name
-  -u, --user=<USER>             kintone username
-  -p, --password=<PASSWORD>     kintone password
-  -a, --app=<APP-ID>            kintone app IDs
-  -g, --guest=<GUEST-SPACE-ID>  kintone guest space ID
-  -b, --basic=<USER[:PASSWORD]> kintone Basic Authentication user and password
-  -A, --appName=<APP-NAME>      Set target app name
-  -l, --location=<LOCATION>     Location of settings file
-  -t, --fileType=<FILE-TYPE>    Set file type 'json'(default) or 'js'
+  -v, --version                    Output version information
+  -h, --help                       Output usage information
+  -d, --domain=<DOMAIN>            kintone domain name
+  -u, --user=<USER>                kintone username
+  -p, --password=<PASSWORD>        kintone password
+  -a, --app=<APP-ID>               kintone app IDs
+  -g, --guest=<GUEST-SPACE-ID>     kintone guest space ID
+  -b, --basic=<USER[:PASSWORD]>    kintone Basic Authentication user and password
+  -A, --appName=<APP-NAME>         Set target app name
+  -l, --location=<LOCATION>        Location of settings file
+  -t, --fileType=<FILE-TYPE>       Set file type 'json'(default) or 'js'
+  -F, --pfxFilepath=<PFX-FILEPATH> The path to client certificate file.
+  -P, --pfxPassword=<PFX-PASSWORD> The password of client certificate.
 ```
 
 * `domain` `user` `password` `app`オプションを省略した場合、標準入力を求められます。
 * アプリID（`app`オプション or 標準入力）はカンマ区切りで複数指定可能です。
 * ゲストスペース内のアプリ情報を取得する場合は`guest`オプションが必須です。
 * Basic認証を使用する場合は`basic`オプションが必須です。パスワードを省略した場合、標準入力を求められます。
+* クライアント証明書を使用する場合は`pfxFilepath` `pfxPassword`オプションが必須です。`pfxPassword`を省略した場合、標準入力を求められます。
 * `location`オプションを指定すると、kintone設定情報ファイルの保存フォルダを指定できます。（省略時はカレントディレクトリ）
 * `fileType`オプションに`js`を指定すると、kintone設定情報ファイルを`.json`ではなく`.js`フォーマットで扱います。
 * コマンドライン引数のほか、後述する`.ginuerc`や`.netrc`でもオプション指定が可能です
-  * `username`, `password`, `basic`については環境変数でも設定可能です。（`GINUE_USERNAME`, `GINUE_PASSWORD`, `GINUE_BASIC`）
+  * `username`, `password`, `basic`, `pfxFilepath`, `pfxPassword`については環境変数でも設定可能です。
+  （`GINUE_USERNAME`, `GINUE_PASSWORD`, `GINUE_BASIC`, `GINUE_PFX_FILEPATH`, `GINUE_PFX_PASSWORD`）
   * 優先順位は `環境変数 < .netrc < .ginuerc < 引数`
 
 #### .ginuerc

--- a/index.js
+++ b/index.js
@@ -25,6 +25,8 @@ const main = async () => {
           base64Account,
           base64Basic,
           apps: opts.apps,
+          pfxFilepath: opts.pfxFilepath,
+          pfxPassword: opts.pfxPassword,
         }
         switch (opts.type) {
           case 'reset':
@@ -47,6 +49,8 @@ const main = async () => {
         guestSpaceId: opts.pushTarget.guestSpaceId,
         base64Basic: await createBase64Account(opts.pushTarget.basic),
         base64Account: await createBase64Account(opts.pushTarget.username, opts.pushTarget.password),
+        pfxFilepath: opts.pushTarget.pfxFilepath,
+        pfxPassword: opts.pushTarget.pfxPassword,
       }
 
       // TODO: スペース単位ループを可能にする(スペース内全アプリをpull)
@@ -75,6 +79,8 @@ const main = async () => {
             command: commName,
             appParam: commProp.appParam,
             methods: commProp.methods,
+            pfxFilepath: opts.pfxFilepath,
+            pfxPassword: opts.pfxPassword,
           }
           switch (opts.type) {
             case 'pull':

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const fetch = require('node-fetch-with-proxy')
+const https = require('https')
+const fs = require('fs')
 
 const createUrl = (ktn) => {
   const basePath = ktn.guestSpaceId ? `k/guest/${ktn.guestSpaceId}/v1` : 'k/v1'
@@ -29,6 +31,17 @@ const createHeaders = (ktn) => {
   return header
 }
 
+const createArgent = (ktn) => {
+  if (!ktn.pfxFilepath || !ktn.pfxPassword) {
+    return
+  }
+
+  return new https.Agent({
+    pfx: fs.readFileSync(ktn.pfxFilepath),
+    passphrase: ktn.pfxPassword,
+  })
+}
+
 const formatFetchError = async (response) => {
   const { status, statusText, type, url } = response
   const bodyText = await response.text()
@@ -42,7 +55,7 @@ const formatFetchError = async (response) => {
 }
 
 const fetchKintoneInfo = async (ktn) => {
-  const response = await fetch(createGetUrl(ktn), { headers: createHeaders(ktn) }, ktn.proxy)
+  const response = await fetch(createGetUrl(ktn), { headers: createHeaders(ktn), agent: createArgent(ktn) }, ktn.proxy)
   if (response.ok) {
     return response.json()
   } else {
@@ -57,6 +70,7 @@ const sendKintoneInfo = async (method, ktn, kintoneInfo) => {
       method,
       headers: { ...createHeaders(ktn), 'Content-Type': 'application/json' },
       body: JSON.stringify(kintoneInfo),
+      agent: createArgent(ktn),
     },
     ktn.proxy
   )
@@ -70,7 +84,7 @@ const sendKintoneInfo = async (method, ktn, kintoneInfo) => {
 const downloadFile = async (ktn, fileKey) => {
   const response = await fetch(
     `https://${ktn.domain}/k/v1/file.json?fileKey=${fileKey}`,
-    { headers: createHeaders(ktn) },
+    { headers: createHeaders(ktn), agent: createArgent(ktn) },
     ktn.proxy
   )
   if (response.ok) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -131,6 +131,13 @@ const stdInputOptions = async (opts) => {
     (await inputKintoneInfo('password', TYPE_PASSWORD))
   opts.basic = opts.basic || process.env.GINUE_BASIC
 
+  // クライアント認証書のオプション
+  opts.pfxFilepath = opts.pfxFilepath || process.env.GINUE_PFX_FILEPATH
+  opts.pfxPassword =
+    opts.pfxPassword ||
+    process.env.GINUE_PFX_PASSWORD ||
+    (opts.pfxFilepath && (await inputKintoneInfo('client certificate password', TYPE_PASSWORD)))
+
   opts.app = opts.app || (await inputKintoneInfo('app'))
   console.log()
   // TODO: 「is guest space?(Y/N)」のように問い合わせて、YならguestSpaceIdを入力
@@ -142,7 +149,20 @@ const parseArgumentOptions = () => {
     // booleanを明記するとデフォルトfalseになってginuercとマージしづらいので書かない
     // 有効なオプションが分かるようにコメントとしては残しておく
     // boolean: ['version', 'help', 'preview', 'acl', 'alt'],
-    string: ['location', 'domain', 'username', 'password', 'app', 'guest', 'basic', 'exclude', 'fileType', 'appName'],
+    string: [
+      'location',
+      'domain',
+      'username',
+      'password',
+      'app',
+      'guest',
+      'basic',
+      'exclude',
+      'fileType',
+      'appName',
+      'pfxFilepath',
+      'pfxPassword',
+    ],
     alias: {
       v: 'version',
       h: 'help',
@@ -156,6 +176,8 @@ const parseArgumentOptions = () => {
       x: 'exclude',
       t: 'fileType',
       A: 'appName',
+      F: 'pfxFilepath',
+      P: 'pfxPassword',
     },
   })
   if (argv.domain || argv.username || argv.password || argv.app || argv.guest) {
@@ -210,6 +232,8 @@ const pluckOpts = (firstObj, secondObj) => {
     alt: obj.alt,
     commands: obj.commands,
     downloadJs: obj.downloadJs,
+    pfxFilepath: obj.pfxFilepath,
+    pfxPassword: obj.pfxPassword,
   }
 
   // Basic認証のパスワード有無でプロパティ名を変えておく

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "https": "^1.0.0",
     "inquirer": "^8.0.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,6 +1402,11 @@ https-proxy-agent@^3.0.0:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
+https@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/https/-/https-1.0.0.tgz#3c37c7ae1a8eeb966904a2ad1e975a194b7ed3a4"
+  integrity sha1-PDfHrhqO65ZpBKKtHpdaGUt+06Q=
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
@the-red 

こちらのツールにはいつもお世話になっています。ありがとうございます。

本題ですが、仕事先でkintoneにクライアント証明書を導入し、現状だと使用することができなくなりましたので、下記改修をさせていただきました。

- kintone api 実行時に、クライアント証明書の指定がある場合は fetch 関数の agent オプションを追加
- コマンドのオプションにクライアント証明書の指定を追加（README参照）
  - クライアント証明書のファイルパス `-F` ` --pfxFilepath` を追加
  - クライアント証明書のパスワード `-P` `--pfxPassword` を追加
- 環境変数にクライアント証明書の指定を追加（README参照）
  - クライアント証明書のファイルパス `GINUE_PFX_FILEPATH` を追加
  - クライアント証明書のパスワード `GINUE_PFX_PASSWORD` を追加
- クライアント証明書のファイルパスを指定していて、パスワードが未指定の場合は標準入力で問い合わせる

よろしくお願いします。